### PR TITLE
build: add docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json .
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 5174
+
+CMD [ "npm", "run", "dev" ]

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,17 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
-// https://vitejs.dev/config/
 export default defineConfig({
+  base: "/",
   plugins: [react()],
-})
+  preview: {
+    port: 8080,
+    strictPort: true,
+  },
+  server: {
+    port: 8080,
+    strictPort: true,
+    host: true,
+    origin: "http://0.0.0.0:8080",
+  },
+});


### PR DESCRIPTION
Agrega el Dockerfile para poder hacer la imagen y correrlo en un container. Cambia en que puerto por defecto corre, ahora pasaria a ser el 8080.
Esto sirve para que despues unicamente teniendo un docker-compose y un .env sin siquiera pullear de los repos, pueda correr la app en cualquier maquina